### PR TITLE
Pass template context as dict instead of as Context

### DIFF
--- a/mailviews/messages.py
+++ b/mailviews/messages.py
@@ -29,7 +29,7 @@ class EmailMessageView(object):
         """
         Returns the context that will be used for rendering this message.
 
-        :rtype: :class:`django.template.Context`
+        :rtype: :class:`dict`
         """
         return kwargs
 
@@ -151,7 +151,7 @@ class TemplatedEmailMessageView(EmailMessageView):
         entities in ``text/plain`` content.
 
         :param context: The context to use when rendering the subject template.
-        :type context: :class:`~django.template.Context`
+        :type context: :class:`dict`
         :returns: A rendered subject.
         :rtype: :class:`str`
         """
@@ -166,7 +166,7 @@ class TemplatedEmailMessageView(EmailMessageView):
         entities in ``text/plain`` content.
 
         :param context: The context to use when rendering the body template.
-        :type context: :class:`~django.template.Context`
+        :type context: :class:`dict`
         :returns: A rendered body.
         :rtype: :class:`str`
         """
@@ -211,7 +211,7 @@ class TemplatedHTMLEmailMessageView(TemplatedEmailMessageView):
         Renders the message body for the given context.
 
         :param context: The context to use when rendering the body template.
-        :type context: :class:`~django.template.Context`
+        :type context: :class:`dict`
         :returns: A rendered HTML body.
         :rtype: :class:`str`
         """

--- a/mailviews/messages.py
+++ b/mailviews/messages.py
@@ -3,8 +3,6 @@ from django.core.mail.message import EmailMessage, EmailMultiAlternatives
 from django.template import Context
 from django.template.loader import get_template, select_template
 
-from mailviews.utils import unescape
-
 
 class EmailMessageView(object):
     """
@@ -34,7 +32,7 @@ class EmailMessageView(object):
 
         :rtype: :class:`django.template.Context`
         """
-        return Context(kwargs)
+        return kwargs
 
     def render_to_message(self, extra_context=None, **kwargs):
         """
@@ -158,7 +156,7 @@ class TemplatedEmailMessageView(EmailMessageView):
         :returns: A rendered subject.
         :rtype: :class:`str`
         """
-        rendered = self.subject_template.render(unescape(context))
+        rendered = self.subject_template.render(context)
         return rendered.strip()
 
     def render_body(self, context):
@@ -173,7 +171,7 @@ class TemplatedEmailMessageView(EmailMessageView):
         :returns: A rendered body.
         :rtype: :class:`str`
         """
-        return self.body_template.render(unescape(context))
+        return self.body_template.render(context)
 
 
 class TemplatedHTMLEmailMessageView(TemplatedEmailMessageView):

--- a/mailviews/messages.py
+++ b/mailviews/messages.py
@@ -1,6 +1,5 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail.message import EmailMessage, EmailMultiAlternatives
-from django.template import Context
 from django.template.loader import get_template, select_template
 
 

--- a/mailviews/tests/tests.py
+++ b/mailviews/tests/tests.py
@@ -77,7 +77,7 @@ class TemplatedEmailMessageViewTestCase(EmailMessageViewTestCase):
             'body': self.body,
         }
 
-        self.context = Context(self.context_dict)
+        self.context = self.context_dict
 
         self.render_subject = functools.partial(self.message.render_subject,
             context=self.context)

--- a/mailviews/tests/tests.py
+++ b/mailviews/tests/tests.py
@@ -6,7 +6,7 @@ from django.core import mail
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import Client
-from django.template import Context, Template, TemplateDoesNotExist
+from django.template import Template, TemplateDoesNotExist
 from django.template.loader import get_template
 
 from mailviews.messages import (TemplatedEmailMessageView,


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.11/releases/1.11/#django-template-backends-django-template-render-prohibits-non-dict-context